### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ zcu102_9371|Xilinx ZCU102 dev board + ADRV9371|Future|Future
 
 ## Quick start
 - Burn openwifi board specific img file (from the table) into a SD card ("Open With Disk Image Writer". Or "dd" command after unzip). The SD card has two partitions: BOOT and rootfs. You need to config the **correct files in the BOOT partition** according to the **board you have** by operation on your computer: 
-  - Copy files in **openwifi/board_name** to the base directory of BOOT partiton.
-  - Copy **openwifi/zynqmp-common/Image** (zcu102 board) or **openwifi/zynq-common/uImage** (other boards) to the base directory of BOOT partiton
+  - Copy files in **openwifi/board_name** to the base directory of BOOT partition.
+  - Copy **openwifi/zynqmp-common/Image** (zcu102 board) or **openwifi/zynq-common/uImage** (other boards) to the base directory of BOOT partition
 - Connect two antennas to RXA/TXA ports. Config the board to SD card boot mode (check the board manual). Insert the SD card to the board. Power on. 
 - Login to the board from your PC (PC Ethernet should have IP 192.168.10.1) with password **openwifi**.
   ```
@@ -81,7 +81,7 @@ zcu102_9371|Xilinx ZCU102 dev board + ADRV9371|Future|Future
   ```
   ~/openwifi/fosdem.sh
   ```
-- After you see the "openwifi" SSID on your device (Phone/Laptop/etc), connect it. Browser to 192.168.13.1 on your deivce, you should see the webpage hosted by the webserver on board.
+- After you see the "openwifi" SSID on your device (Phone/Laptop/etc), connect it. Browser to 192.168.13.1 on your device, you should see the webpage hosted by the webserver on board.
   - Note 1: If your device doesn't support 5GHz (ch44), please change the **hostapd-openwifi.conf** on board and re-run fosdem.sh.
   - Note 2: After ~2 hours, the Viterbi decoder will halt (Xilinx Evaluation License). Just power cycle the board if it happens. (If output of "./sdrctl dev sdr0 get reg rx 20" is always the same, it means the decoder halts)
 - To give the Wi-Fii client internet access, configure routing/NAT **on the PC**:
@@ -115,7 +115,7 @@ The board actually is an Linux/Ubuntu computer which is running **hostapd** to o
 
 ## Update FPGA
 
-Since the pre-built SD card image might not have the latest bug-fixes/updates, it is recommended to udpate the fpga bitstream on board.
+Since the pre-built SD card image might not have the latest bug-fixes/updates, it is recommended to update the fpga bitstream on board.
 
 - Install Vivado/SDK 2018.3 (If you don't need to generate new FPGA bitstream, WebPack version without license is enough)
 - Setup environment variables (use absolute path):
@@ -146,7 +146,7 @@ Since the pre-built SD card image might not have the latest bug-fixes/updates, i
 
 ## Update Driver
 
-Since the pre-built SD card image might not have the latest bug-fixes/updates, it is recommended to udpate the driver on board.
+Since the pre-built SD card image might not have the latest bug-fixes/updates, it is recommended to update the driver on board.
 - Prepare Analog Devices Linux kernel source code (only need to run once):
   ```
   $OPENWIFI_DIR/user_space/prepare_kernel.sh $OPENWIFI_DIR $XILINX_DIR ARCH_BIT
@@ -239,7 +239,7 @@ This section explains the porting work by showing the differences between openwi
 - Open the fmcomms2 + zc706 reference design at hdl/projects/fmcomms2/zc706 (Please read Analog Devices help)
 - Open the openwifi design zc706_fmcs2 at openwifi-hw/boards/zc706_fmcs2 (Please read openwifi-hw repository)
 - "Open Block Design", you will see the differences between openwifi and the reference design. Both in "diagram" and in "Address Editor".
-- The address/interrupts of FPGA blocks hooked to the ARM bus should be put/aligned to the devicetree file openwifi/kernel_boot/boards/zc706_fmcs2/devicetree.dts. Linux will parse the devicetree.dtb when booting to know information of attached deivce (FPGA blocks in our case).
+- The address/interrupts of FPGA blocks hooked to the ARM bus should be put/aligned to the devicetree file openwifi/kernel_boot/boards/zc706_fmcs2/devicetree.dts. Linux will parse the devicetree.dtb when booting to know information of attached device (FPGA blocks in our case).
 - We use dtc command to get devicetree.dts converted from devicetree.dtb in [Analog Devices Linux image](https://wiki.analog.com/resources/tools-software/linux-software/zynq_images), then do modification according to what we have added/modified to the reference design.
 - Please learn the script in [[Build openwifi Linux img from scratch](#Build-openwifi-Linux-img-from-scratch)] to understand how we generate devicetree.dtb, BOOT.BIN and Linux kernel uImage and put them together to build the full SD card image.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -60,7 +60,7 @@ sdrctl dev sdr0 set para_name value
 ```
 para_name|meaning|comment
 ---------|-------|----
-slice_idx|the slice that will be set/get|0~3. After finishing all slice config, **set slice_idx to 4** to synchronize all slices. Otherwize the start/end of different slices have different actual time
+slice_idx|the slice that will be set/get|0~3. After finishing all slice config, **set slice_idx to 4** to synchronize all slices. Otherwise the start/end of different slices have different actual time
 addr|target MAC address of tx slice_idx|32bit. for address 6c:fd:b9:4c:b1:c1, you set b94cb1c1
 slice_total|tx slice_idx cycle length in us|for length 50ms, you set 49999
 slice_start|tx slice_idx cycle start time in us|for start at 10ms, you set 10000
@@ -280,8 +280,8 @@ and use dmesg command in Linux to see those messages. openwifi driver prints nor
 sdr,sdr openwifi_tx_interrupt: tx_result 02 prio2 wr28 rd25 num_rand_slot 21 cw 6 
 ```
   - printing from sdr driver, openwifi_tx_interrupt function.
-  - tx_result: 5 bit, lower 4 bit tells how many tx attemps are made on this packet, and the 5th bit indicates no ack (1) or an ack (0) is received
-  - prio, wr, rd: these fileds can be interpreted the same way as the print in openwifi_tx function
+  - tx_result: 5 bit, lower 4 bit tells how many tx attempts are made on this packet, and the 5th bit indicates no ack (1) or an ack (0) is received
+  - prio, wr, rd: these fields can be interpreted the same way as the print in openwifi_tx function
   - num_rand_slot: tells how many slots the CSMA/CA state machine waited until the packet is sent in the last tx attempt.
   - cw: tells the exponent of the contention window. For this packet, the exponent 6 means the contention window size is 64. If the contention phase is never entered, the cw is set to 0. 
   
@@ -305,4 +305,4 @@ For protocol, many native Linux tools you still could rely on. Such as tcpdump.
 
 ### FPGA
 
-For FPGA itself, FPGA developer could use Xilinx ILA tools to analyze FPGA signals. Spying on those state machines in xpu/tx_intf/rx_intf would be very helpful for understanding/debugging Wi-Fi low level funtionalities.
+For FPGA itself, FPGA developer could use Xilinx ILA tools to analyze FPGA signals. Spying on those state machines in xpu/tx_intf/rx_intf would be very helpful for understanding/debugging Wi-Fi low level functionalities.

--- a/doc/app_notes/ad-hoc-two-sdr.md
+++ b/doc/app_notes/ad-hoc-two-sdr.md
@@ -19,7 +19,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   (Above command setup ad-hoc network at channel 44 with static IP assigned to sdr0 NIC)
   iwconfig sdr0
   ```
-- You shold see output like:
+- You should see output like:
   ```
   sdr0    IEEE 802.11  ESSID:"sdr-ad-hoc"  
           Mode:Ad-Hoc  Frequency:5.22 GHz  Cell: 92:CA:14:27:1E:B0   
@@ -41,7 +41,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   ./sdr-ad-hoc-up.sh sdr0 44 192.168.13.1
   iwconfig sdr0
   ```
-- You shold see output like:
+- You should see output like:
   ```
   sdr0    IEEE 802.11  ESSID:"sdr-ad-hoc"  
           Mode:Ad-Hoc  Frequency:5.22 GHz  Cell: 92:CA:14:27:1E:B0   

--- a/doc/app_notes/csi.md
+++ b/doc/app_notes/csi.md
@@ -37,7 +37,7 @@ We extend the **CSI** (Channel State Information) to **CSI** (Chip State Informa
   The python script needs "matplotlib.pyplot" and "numpy" packages installed. Now you should see 3 figures showing run-time **frequency offset**, **channel state/response** and **constellation form equalizer**. Meanwhile the python script prints the **timestamp**.
   ![](./csi-screen-shot.jpg)
   
-  While running, all informations are also stored into a file **side_info.txt**. A matlab script **test_side_info_file_display.m** is offered to help you do analysis on the Chip State Information offline.
+  While running, all information is also stored into a file **side_info.txt**. A matlab script **test_side_info_file_display.m** is offered to help you do analysis on the Chip State Information offline.
 
 ## Understand the CSI feature
   The CSI information is extracted via the openwifi **side channel** infrastructure. This figure explains the related modules (also related source code file name) and how the information goes from the SDR board to the computer.
@@ -54,7 +54,7 @@ We extend the **CSI** (Channel State Information) to **CSI** (Chip State Informa
   The python and Matlab scripts are recommended for you to understand the CSI packet format precisely.
 
 ## Config the capture condition and interval
-  The quick start guide will monitor all CSI informations of all packets decoded by the WiFi ofdm receiver. To monitor only specific packets that match the specific conditions: FC (Frame Control), addr1 (target MAC address), addr2 (source MAC address), configuration command should be issued before executing "**side_ch_ctl g**". The configuration command is realized by feeding a different parameter to "**side_ch_ctl**". 
+  The quick start guide will monitor all CSI information of all packets decoded by the WiFi ofdm receiver. To monitor only specific packets that match the specific conditions: FC (Frame Control), addr1 (target MAC address), addr2 (source MAC address), configuration command should be issued before executing "**side_ch_ctl g**". The configuration command is realized by feeding a different parameter to "**side_ch_ctl**". 
   
   A quick example: Capture only CSI of those packets from the device with MAC address 56:5b:01:ec:e2:8f
   ```
@@ -101,7 +101,7 @@ We extend the **CSI** (Channel State Information) to **CSI** (Chip State Informa
   The interval will become N*1ms
 
 ## Config the num_eq
-  The num_eq (number of equalizer output) is configurable in case you don't need so many equalizer informations. The valid value is 0~8. You should align the num_eq value at the side_ch.ko, side_info_display.py and test_side_info_file_display.m. 
+  The num_eq (number of equalizer output) is configurable in case you don't need so many equalizer information. The valid value is 0~8. You should align the num_eq value at the side_ch.ko, side_info_display.py and test_side_info_file_display.m. 
   - When insert the kernel module, use:
   ```
   insmod side_ch.ko num_eq_init=3

--- a/doc/app_notes/iq.md
+++ b/doc/app_notes/iq.md
@@ -43,7 +43,7 @@ We implement the **IQ sample capture** with interesting extensions: many **trigg
   The python script needs "matplotlib.pyplot" and "numpy" packages installed. Now you should see 3 figures showing run-time **IQ sample**, **AGC gain and lock status** and **RSSI (uncalibrated)**. Meanwhile the python script prints the **timestamp**.
   ![](./iq-screen-shot.jpg)
   
-  While running, all informations are also stored into a file **iq.txt**. A matlab script **test_iq_file_display.m** is offered to help you do analysis on the IQ Information offline. For zed, adrv9364z7020, zc702 board, do not forget to change the **iq_len** in the matlab script to 4095.
+  While running, all information is also stored into a file **iq.txt**. A matlab script **test_iq_file_display.m** is offered to help you do analysis on the IQ Information offline. For zed, adrv9364z7020, zc702 board, do not forget to change the **iq_len** in the matlab script to 4095.
 
 ## Understand the IQ capture feature
   The IQ information is extracted via the openwifi **side channel** infrastructure. This figure explains the related modules (also related source code file name) and how the information goes from the SDR board to the computer.
@@ -131,7 +131,7 @@ We implement the **IQ sample capture** with interesting extensions: many **trigg
   The interval will become N*1ms
 
 ## Config the iq_len
-  The **iq_len** (number of IQ sample per capture) is configurable in case you want less IQ samples per capture so that it can be triggered more times during a specific analysis period. The valid value is 1~**8187**. For **small FPGA** (zed_fmcs2, adrv9364z7020, zc702), the valid range is 0 ~ **4095**. It is independant from pre_trigger_len, and it can be less than pre_trigger_len if you want. You should align the **iq_len** value at the side_ch.ko, iq_capture.py and test_iq_file_display.m. 
+  The **iq_len** (number of IQ sample per capture) is configurable in case you want less IQ samples per capture so that it can be triggered more times during a specific analysis period. The valid value is 1~**8187**. For **small FPGA** (zed_fmcs2, adrv9364z7020, zc702), the valid range is 0 ~ **4095**. It is independent from pre_trigger_len, and it can be less than pre_trigger_len if you want. You should align the **iq_len** value at the side_ch.ko, iq_capture.py and test_iq_file_display.m. 
   - When insert the kernel module, use:
   ```
   insmod side_ch.ko iq_len_init=3000

--- a/driver/ad9361/ad9361_regs.h
+++ b/driver/ad9361/ad9361_regs.h
@@ -2280,7 +2280,7 @@
 #define POWER_DOWN_VARACTOR_REF		     (1 << 3) /* Power Down Varactor Ref */
 #define PWR_DOWN_VARACT_REF_TCF		     (1 << 2) /* Pwr Down Varact Ref Tcf */
 #define POWER_DOWN_CAL_TCF		     (1 << 1) /* Power Down Cal Tcf */
-#define POWER_DOWN_VCO_BUFFFER		     (1 << 0) /* Power Down VCO Bufffer */
+#define POWER_DOWN_VCO_BUFFER		     (1 << 0) /* Power Down VCO Buffer */
 
 /*
  * REG_RX_CP_OVERRANGE_VCO_LOCK
@@ -2515,7 +2515,7 @@
 #define POWER_DOWN_VARACTOR_REF		     (1 << 3) /* Power Down Varactor Ref */
 #define POWER_DOWN_VARACT_REF_TCF	     (1 << 2) /* Power Down Varact Ref Tcf */
 #define POWER_DOWN_CAL_TCF		     (1 << 1) /* Power Down Cal Tcf */
-#define POWER_DOWN_VCO_BUFFFER		     (1 << 0) /* Power Down VCO Bufffer */
+#define POWER_DOWN_VCO_BUFFER		     (1 << 0) /* Power Down VCO Buffer */
 
 /*
  * REG_TX_CP_OVERRANGE_VCO_LOCK

--- a/driver/rx_intf/rx_intf.c
+++ b/driver/rx_intf/rx_intf.c
@@ -289,7 +289,7 @@ static inline u32 hw_init(enum rx_intf_mode mode, u32 num_dma_symbol_to_pl, u32 
 		
 		//rx_intf_api->RX_INTF_REG_INTERRUPT_TEST_write(0x000);
 		rx_intf_api->RX_INTF_REG_INTERRUPT_TEST_write(0x100);
-		//0x000-normal; 0x100-sig and fcs valid are controled by bit4 and bit0;
+		//0x000-normal; 0x100-sig and fcs valid are controlled by bit4 and bit0;
 		//0x111-sig and fcs high; 0x110-sig high fcs low; 0x101-sig low fcs high; 0x100-sig and fcs low
 
 		rx_intf_api->RX_INTF_REG_IQ_SRC_SEL_write(0);

--- a/driver/sdr.c
+++ b/driver/sdr.c
@@ -233,7 +233,7 @@ static int openwifi_init_tx_ring(struct openwifi_priv *priv, int ring_idx)
 	for (i = 0; i < NUM_TX_BD; i++) {
 		ring->bds[i].skb_linked=0; // for tx, skb is from upper layer
 		//at first right after skb allocated, head, data, tail are the same.
-		ring->bds[i].dma_mapping_addr = 0; // for tx, mapping is done after skb is received from uppler layer in tx routine
+		ring->bds[i].dma_mapping_addr = 0; // for tx, mapping is done after skb is received from upper layer in tx routine
 	}
 
 	return 0;

--- a/driver/sdr.c
+++ b/driver/sdr.c
@@ -232,7 +232,7 @@ static int openwifi_init_tx_ring(struct openwifi_priv *priv, int ring_idx)
 
 	for (i = 0; i < NUM_TX_BD; i++) {
 		ring->bds[i].skb_linked=0; // for tx, skb is from upper layer
-		//at frist right after skb allocated, head, data, tail are the same.
+		//at first right after skb allocated, head, data, tail are the same.
 		ring->bds[i].dma_mapping_addr = 0; // for tx, mapping is done after skb is received from uppler layer in tx routine
 	}
 
@@ -697,7 +697,7 @@ static void openwifi_tx(struct ieee80211_hw *dev,
 				}
 			}
 		//}
-		queue_idx = (i>=MAX_NUM_HW_QUEUE?2:i); // if no address is hit, use FPGA queue 2. becuase the queue 2 is the longest.
+		queue_idx = (i>=MAX_NUM_HW_QUEUE?2:i); // if no address is hit, use FPGA queue 2. because the queue 2 is the longest.
 	}
 	// -------------------- end of Map Linux/SW "prio" to hardware "queue_idx" ------------------
 
@@ -851,8 +851,8 @@ static void openwifi_tx(struct ieee80211_hw *dev,
 	 */
 	//wmb();
 	// entry->flags = cpu_to_le32(tx_flags);
-	/* We must be sure this has been written before followings HW
-	 * register write, because this write will made the HW attempts
+	/* We must be sure this has been written before following HW
+	 * register write, because this write will make the HW attempts
 	 * to DMA the just-written data
 	 */
 	//wmb();
@@ -911,7 +911,7 @@ static void openwifi_tx(struct ieee80211_hw *dev,
 		goto openwifi_tx_after_dma_mapping;
 	}
 
-	// seems everything ok. let's mark this pkt in bd descriptor ring
+	// seems everything is ok. let's mark this pkt in bd descriptor ring
 	ring->bds[ring->bd_wr_idx].skb_linked = skb;
 	ring->bds[ring->bd_wr_idx].dma_mapping_addr = dma_mapping_addr;
 
@@ -998,7 +998,7 @@ static int openwifi_start(struct ieee80211_hw *dev)
 	xpu_api->XPU_REG_RSSI_DB_CFG_write((~0x80000000)&((rssi_half_db_offset<<16)|agc_gain_delay) );
 	
 	openofdm_rx_api->OPENOFDM_RX_REG_POWER_THRES_write(0);
-	// rssi_half_db_th = 87<<1; // -62dBm // will settup in runtime in _rf_set_channel
+	// rssi_half_db_th = 87<<1; // -62dBm // will setup in runtime in _rf_set_channel
 	// xpu_api->XPU_REG_LBT_TH_write(rssi_half_db_th); // set IQ rssi th step .5dB to xxx and enable it
 	reg=xpu_api->XPU_REG_LBT_TH_read();
 	xpu_api->XPU_REG_LBT_TH_write((reg & 0xFF00FFFF) | (75 << 16) ); // bit 23:16 of LBT TH reg is set to control the duration to force ch_idle after decoding a packet due to imperfection of agc and signals
@@ -2197,7 +2197,7 @@ static int openwifi_dev_probe(struct platform_device *pdev)
 	}
 
 	// // //--------------------hook leds (not complete yet)--------------------------------
-	// tmp_dev = bus_find_device( &platform_bus_type, NULL, "leds", custom_match_platform_dev ); //leds is the name in devicetree, not "compatiable" field
+	// tmp_dev = bus_find_device( &platform_bus_type, NULL, "leds", custom_match_platform_dev ); //leds is the name in devicetree, not "compatible" field
 	// if (!tmp_dev) {
 	// 	printk(KERN_ERR "%s bus_find_device platform_bus_type leds-gpio failed\n",sdr_compatible_str);
 	// 	err = -ENOMEM;

--- a/driver/sdr.h
+++ b/driver/sdr.h
@@ -6,7 +6,7 @@
 #define OPENWIFI_SDR
 
 // -------------------for leds--------------------------------
-struct gpio_led_data { //pleas always align with the leds-gpio.c in linux kernel
+struct gpio_led_data { //please always align with the leds-gpio.c in linux kernel
 	struct led_classdev cdev;
 	struct gpio_desc *gpiod;
 	u8 can_sleep;
@@ -14,7 +14,7 @@ struct gpio_led_data { //pleas always align with the leds-gpio.c in linux kernel
 	gpio_blink_set_t platform_gpio_blink_set;
 };
 
-struct gpio_leds_priv { //pleas always align with the leds-gpio.c in linux kernel
+struct gpio_leds_priv { //please always align with the leds-gpio.c in linux kernel
 	int num_leds;
 	struct gpio_led_data leds[];
 };

--- a/driver/xilinx_dma/xilinx_dma.c
+++ b/driver/xilinx_dma/xilinx_dma.c
@@ -419,7 +419,7 @@ struct xilinx_dma_config {
  * @ext_addr: Indicates 64 bit addressing is supported by dma device
  * @pdev: Platform device structure pointer
  * @dma_config: DMA config structure
- * @axi_clk: DMA Axi4-lite interace clock
+ * @axi_clk: DMA Axi4-lite interface clock
  * @tx_clk: DMA mm2s clock
  * @txs_clk: DMA mm2s stream clock
  * @rx_clk: DMA s2mm clock

--- a/driver/xilinx_dma/xilinx_dma.c
+++ b/driver/xilinx_dma/xilinx_dma.c
@@ -2249,12 +2249,12 @@ int xilinx_vdma_channel_set_config(struct dma_chan *dchan,
 	else
 		chan->config.park_frm = -1;
 
-	chan->config.coalesc = cfg->coalesc;
+	chan->config.coalesce = cfg->coalesce;
 	chan->config.delay = cfg->delay;
 
-	if (cfg->coalesc <= XILINX_DMA_DMACR_FRAME_COUNT_MAX) {
-		dmacr |= cfg->coalesc << XILINX_DMA_DMACR_FRAME_COUNT_SHIFT;
-		chan->config.coalesc = cfg->coalesc;
+	if (cfg->coalesce <= XILINX_DMA_DMACR_FRAME_COUNT_MAX) {
+		dmacr |= cfg->coalesce << XILINX_DMA_DMACR_FRAME_COUNT_SHIFT;
+		chan->config.coalesce = cfg->coalesce;
 	}
 
 	if (cfg->delay <= XILINX_DMA_DMACR_DELAY_MAX) {

--- a/user_space/inject_80211/radiotap.c
+++ b/user_space/inject_80211/radiotap.c
@@ -107,7 +107,7 @@ int ieee80211_radiotap_iterator_init(
  * present fields.  @this_arg can be changed by the caller (eg,
  * incremented to move inside a compound argument like
  * IEEE80211_RADIOTAP_CHANNEL).  The args pointed to are in
- * little-endian format whatever the endianess of your CPU.
+ * little-endian format whatever the endianness of your CPU.
  */
 
 int ieee80211_radiotap_iterator_next(

--- a/user_space/rf_init.sh
+++ b/user_space/rf_init.sh
@@ -85,7 +85,7 @@ echo "rssi"
 cat in_voltage0_rssi
 cat in_voltage1_rssi
 
-# #  --------not neede maybe-------- # #
+# #  --------not needed maybe-------- # #
 echo "rx0 gain to 70" # this set gain is gpio gain - 5dB (test with agc and read back gpio in driver)
 cat in_voltage0_hardwaregain
 echo 70 > in_voltage0_hardwaregain
@@ -109,7 +109,7 @@ cat out_voltage1_hardwaregain
 echo 0 > out_voltage1_hardwaregain
 cat out_voltage1_hardwaregain
 sync
-# #  --------not neede maybe-------- # #
+# #  --------not needed maybe-------- # #
 
 cd $home_dir
 

--- a/user_space/sdrctl_src/nl80211.h
+++ b/user_space/sdrctl_src/nl80211.h
@@ -396,7 +396,7 @@
  *	%NL80211_ATTR_SCHED_SCAN_PLANS. If %NL80211_ATTR_SCHED_SCAN_PLANS is
  *	not specified and only %NL80211_ATTR_SCHED_SCAN_INTERVAL is specified,
  *	scheduled scan will run in an infinite loop with the specified interval.
- *	These attributes are mutually exculsive,
+ *	These attributes are mutually exclusive,
  *	i.e. NL80211_ATTR_SCHED_SCAN_INTERVAL must not be passed if
  *	NL80211_ATTR_SCHED_SCAN_PLANS is defined.
  *	If for some reason scheduled scan is aborted by the driver, all scan
@@ -570,7 +570,7 @@
  *	authentication/association or not receiving a response from the AP.
  *	Non-zero %NL80211_ATTR_STATUS_CODE value is indicated in that case as
  *	well to remain backwards compatible.
- * @NL80211_CMD_ROAM: notifcation indicating the card/driver roamed by itself.
+ * @NL80211_CMD_ROAM: notification indicating the card/driver roamed by itself.
  *	When the driver roamed in a network that requires 802.1X authentication,
  *	%NL80211_ATTR_PORT_AUTHORIZED should be set if the 802.1X authentication
  *	was done by the driver or if roaming was done using Fast Transition
@@ -736,7 +736,7 @@
  *	inform userspace of the new replay counter.
  *
  * @NL80211_CMD_PMKSA_CANDIDATE: This is used as an event to inform userspace
- *	of PMKSA caching dandidates.
+ *	of PMKSA caching candidates.
  *
  * @NL80211_CMD_TDLS_OPER: Perform a high-level TDLS command (e.g. link setup).
  *	In addition, this can be used as an event to request userspace to take
@@ -772,7 +772,7 @@
  *
  * @NL80211_CMD_PROBE_CLIENT: Probe an associated station on an AP interface
  *	by sending a null data frame to it and reporting when the frame is
- *	acknowleged. This is used to allow timing out inactive clients. Uses
+ *	acknowledged. This is used to allow timing out inactive clients. Uses
  *	%NL80211_ATTR_IFINDEX and %NL80211_ATTR_MAC. The command returns a
  *	direct reply with an %NL80211_ATTR_COOKIE that is later used to match
  *	up the event with the request. The event includes the same data and
@@ -1558,10 +1558,10 @@ enum nl80211_commands {
  *	bit. Depending on which antennas are selected in the bitmap, 802.11n
  *	drivers can derive which chainmasks to use (if all antennas belonging to
  *	a particular chain are disabled this chain should be disabled) and if
- *	a chain has diversity antennas wether diversity should be used or not.
+ *	a chain has diversity antennas whether diversity should be used or not.
  *	HT capabilities (STBC, TX Beamforming, Antenna selection) can be
  *	derived from the available chains after applying the antenna mask.
- *	Non-802.11n drivers can derive wether to use diversity or not.
+ *	Non-802.11n drivers can derive whether to use diversity or not.
  *	Drivers may reject configurations or RX/TX mask combinations they cannot
  *	support by returning -EINVAL.
  *
@@ -1629,7 +1629,7 @@ enum nl80211_commands {
  *	the values passed in @NL80211_ATTR_SCAN_SSIDS (eg. if an SSID
  *	is included in the probe request, but the match attributes
  *	will never let it go through), -EINVAL may be returned.
- *	If ommited, no filtering is done.
+ *	If omitted, no filtering is done.
  *
  * @NL80211_ATTR_INTERFACE_COMBINATIONS: Nested attribute listing the supported
  *	interface combinations. In each nested item, it contains attributes
@@ -1734,7 +1734,7 @@ enum nl80211_commands {
  *
  * @NL80211_ATTR_INACTIVITY_TIMEOUT: timeout value in seconds, this can be
  *	used by the drivers which has MLME in firmware and does not have support
- *	to report per station tx/rx activity to free up the staion entry from
+ *	to report per station tx/rx activity to free up the station entry from
  *	the list. This needs to be used when the driver advertises the
  *	capability to timeout the stations.
  *
@@ -2089,7 +2089,7 @@ enum nl80211_commands {
  *
  * @NL80211_ATTR_SCHED_SCAN_RSSI_ADJUST: When present the RSSI level for BSSs in
  *	the specified band is to be adjusted before doing
- *	%NL80211_ATTR_SCHED_SCAN_RELATIVE_RSSI based comparision to figure out
+ *	%NL80211_ATTR_SCHED_SCAN_RELATIVE_RSSI based comparison to figure out
  *	better BSSs. The attribute value is a packed structure
  *	value as specified by &struct nl80211_bss_select_rssi_adjust.
  *
@@ -2990,7 +2990,7 @@ enum nl80211_mpath_flags {
  * @NL80211_MPATH_INFO_DISCOVERY_TIMEOUT: total path discovery timeout, in msec
  * @NL80211_MPATH_INFO_DISCOVERY_RETRIES: mesh path discovery retries
  * @NL80211_MPATH_INFO_MAX: highest mesh path information attribute number
- *	currently defind
+ *	currently defined
  * @__NL80211_MPATH_INFO_AFTER_LAST: internal use
  */
 enum nl80211_mpath_info {
@@ -3061,7 +3061,7 @@ enum nl80211_band_attr {
  *	(100 * dBm).
  * @NL80211_FREQUENCY_ATTR_DFS_STATE: current state for DFS
  *	(enum nl80211_dfs_state)
- * @NL80211_FREQUENCY_ATTR_DFS_TIME: time in miliseconds for how long
+ * @NL80211_FREQUENCY_ATTR_DFS_TIME: time in milliseconds for how long
  *	this channel is in this DFS state.
  * @NL80211_FREQUENCY_ATTR_NO_HT40_MINUS: HT40- isn't possible with this
  *	channel as the control channel
@@ -4486,7 +4486,7 @@ enum nl80211_attr_coalesce_rule {
 
 /**
  * enum nl80211_coalesce_condition - coalesce rule conditions
- * @NL80211_COALESCE_CONDITION_MATCH: coalaesce Rx packets when patterns
+ * @NL80211_COALESCE_CONDITION_MATCH: coalesce Rx packets when patterns
  *	in a rule are matched.
  * @NL80211_COALESCE_CONDITION_NO_MATCH: coalesce Rx packets when patterns
  *	in a rule are not matched.
@@ -4555,7 +4555,7 @@ enum nl80211_iface_limit_attrs {
  *	numbers = [ #{STA} <= 1, #{P2P-client,P2P-GO} <= 3 ], max = 4
  *	=> allows a STA plus three P2P interfaces
  *
- * The list of these four possiblities could completely be contained
+ * The list of these four possibilities could completely be contained
  * within the %NL80211_ATTR_INTERFACE_COMBINATIONS attribute to indicate
  * that any of these groups must match.
  *
@@ -4585,7 +4585,7 @@ enum nl80211_if_combination_attrs {
  * enum nl80211_plink_state - state of a mesh peer link finite state machine
  *
  * @NL80211_PLINK_LISTEN: initial state, considered the implicit
- *	state of non existant mesh peer links
+ *	state of non existent mesh peer links
  * @NL80211_PLINK_OPN_SNT: mesh plink open frame has been sent to
  *	this mesh peer
  * @NL80211_PLINK_OPN_RCVD: mesh plink open frame has been received
@@ -4745,7 +4745,7 @@ enum nl80211_ap_sme_features {
  * @NL80211_FEATURE_INACTIVITY_TIMER: This driver takes care of freeing up
  *	the connected inactive stations in AP mode.
  * @NL80211_FEATURE_CELL_BASE_REG_HINTS: This driver has been tested
- *	to work properly to suppport receiving regulatory hints from
+ *	to work properly to support receiving regulatory hints from
  *	cellular base stations.
  * @NL80211_FEATURE_P2P_DEVICE_NEEDS_CHANNEL: (no longer available, only
  *	here to reserve the value for API/ABI compatibility)

--- a/user_space/side_ch_ctl_src/side_ch_ctl.c
+++ b/user_space/side_ch_ctl_src/side_ch_ctl.c
@@ -151,7 +151,7 @@ int parse_para_string(char *para, int *action_flag, int *reg_type, int *reg_idx,
     if ( para[0] == 'g'){// || para[0] == 'G' ) {
         (*action_flag) = ACTION_SIDE_INFO_GET;
         
-        if (para_string_len == 1) { // no explict input
+        if (para_string_len == 1) { // no explicit input
             (*interval_ms) = 100;
             printf("The default 100ms side info getting period is taken!\n");
             return(0);


### PR DESCRIPTION
Found via codespell v2.1.dev0  
`codespell -q 3 -L ans,filp,fils,hsi`