### PR TITLE
Fix the issue of iGent env related big ping delay:

### DIFF
--- a/driver/make_all.sh
+++ b/driver/make_all.sh
@@ -39,10 +39,12 @@ if [ "$ARCH_OPTION" == "64" ]; then
     LINUX_KERNEL_SRC_DIR=$OPENWIFI_DIR/adi-linux-64/
     ARCH="arm64"
     CROSS_COMPILE="aarch64-linux-gnu-"
+    echo "#define USE_NEW_RX_INTERRUPT 1" > pre_def.h
 else
     LINUX_KERNEL_SRC_DIR=$OPENWIFI_DIR/adi-linux/
     ARCH="arm"
     CROSS_COMPILE="arm-linux-gnueabihf-"
+    echo "#define USE_NEW_RX_INTERRUPT 1" > pre_def.h
 fi
 
 # check if user entered the right path to analog device linux

--- a/driver/sdr.h
+++ b/driver/sdr.h
@@ -5,6 +5,8 @@
 #ifndef OPENWIFI_SDR
 #define OPENWIFI_SDR
 
+#include "pre_def.h"
+
 // -------------------for leds--------------------------------
 struct gpio_led_data { //please always align with the leds-gpio.c in linux kernel
 	struct led_classdev cdev;
@@ -90,7 +92,13 @@ union u16_byte2 {
 
 #define RING_ROOM_THRESHOLD 4
 #define NUM_TX_BD 64 // !!! should align to the fifo size in tx_bit_intf.v
+
+#ifdef USE_NEW_RX_INTERRUPT
+#define NUM_RX_BD 8
+#else
 #define NUM_RX_BD 16
+#endif
+
 #define TX_BD_BUF_SIZE (8192)
 #define RX_BD_BUF_SIZE (8192)
 


### PR DESCRIPTION
1. The issue only happens at zcu102 side, when it is tested as AP together with zedboard
2. The issue does not happen when zcu102 is client and zedboard is AP
3. The issue (most likely) does not happen in places other than iGent (like Pablo home)
4. Sometimes it does happen at my home when I test zcu102 as AP together with COTS WiFi
5. Indeed seems like the environment related. Guess some quick small packets in the environment quickly flush/round-up/mess-up the rx dma cyclic buffer, and the rx interrupt internal static variable target_buf_idx_old loses track of the background automatic rx dma cyclic buffer
6. The fix is for all board types (zcu102, zedboard, 7035, etc)
7. The driver compiling make_all.sh script generates USE_NEW_RX_INTERRUPT macro to pre_def.h to enable the new code (while keeping the old code). You can use the script as before.
8. The logic of the fix is that exhaustive search all the rx dma cyclic buffer in rx interrupt to get packet to Linux in the first place.
9. The test is OK.