### PR TITLE
Replace '__packed' with '__attribute__'

### DIFF
--- a/user_space/inject_80211/ieee80211_radiotap.h
+++ b/user_space/inject_80211/ieee80211_radiotap.h
@@ -79,7 +79,7 @@ struct ieee80211_radiotap_header {
 				 * Additional extensions are made
 				 * by setting bit 31.
 				 */
-} __packed;
+} __attribute__((__packed__));
 
 /* Name                                 Data type    Units
  * ----                                 ---------    -----


### PR DESCRIPTION
Fixes error while building inject_80211:

multiple definition of `__packed'; /tmp/ccS0JGMV.o:(.bss+0x0): first defined here collect2: error: ld returned 1 exit status

Changed based on https://github.com/radiotap/radiotap-library/pull/6