### PR TITLE
Update radar-self-csi.md with needed missing command

### DIFF
--- a/doc/app_notes/radar-self-csi.md
+++ b/doc/app_notes/radar-self-csi.md
@@ -14,6 +14,7 @@ One super power of the openwifi platform is "**Full Duplex**" which means that o
   ssh root@192.168.10.122
   (password: openwifi)
   cd openwifi
+  ./wgd.sh
   ./fosdem.sh
   (After the AP started by above command, you can connect a WiFi client to this openwifi AP)
   (Or setup other scenario according to your requirement)


### PR DESCRIPTION
The `wgd.sh` script is missing in the tutorial notes. 
Without executing this before the `fosdem.sh` script the access point won't start