### PR TITLE
Fixed errors during compilation of OpenWRT kernel modules

### DIFF
--- a/driver/openofdm_rx/openofdm_rx.c
+++ b/driver/openofdm_rx/openofdm_rx.c
@@ -65,7 +65,7 @@ static const struct of_device_id dev_of_ids[] = {
 MODULE_DEVICE_TABLE(of, dev_of_ids);
 
 static struct openofdm_rx_driver_api openofdm_rx_driver_api_inst;
-static struct openofdm_rx_driver_api *openofdm_rx_api = &openofdm_rx_driver_api_inst;
+struct openofdm_rx_driver_api *openofdm_rx_api = &openofdm_rx_driver_api_inst;
 EXPORT_SYMBOL(openofdm_rx_api);
 
 static inline u32 hw_init(enum openofdm_rx_mode mode){

--- a/driver/openofdm_tx/openofdm_tx.c
+++ b/driver/openofdm_tx/openofdm_tx.c
@@ -56,7 +56,7 @@ static const struct of_device_id dev_of_ids[] = {
 MODULE_DEVICE_TABLE(of, dev_of_ids);
 
 static struct openofdm_tx_driver_api openofdm_tx_driver_api_inst;
-static struct openofdm_tx_driver_api *openofdm_tx_api = &openofdm_tx_driver_api_inst;
+struct openofdm_tx_driver_api *openofdm_tx_api = &openofdm_tx_driver_api_inst;
 EXPORT_SYMBOL(openofdm_tx_api);
 
 static inline u32 hw_init(enum openofdm_tx_mode mode){

--- a/driver/rx_intf/rx_intf.c
+++ b/driver/rx_intf/rx_intf.c
@@ -165,7 +165,7 @@ static const struct of_device_id dev_of_ids[] = {
 MODULE_DEVICE_TABLE(of, dev_of_ids);
 
 static struct rx_intf_driver_api rx_intf_driver_api_inst;
-static struct rx_intf_driver_api *rx_intf_api = &rx_intf_driver_api_inst;
+struct rx_intf_driver_api *rx_intf_api = &rx_intf_driver_api_inst;
 EXPORT_SYMBOL(rx_intf_api);
 
 static inline u32 hw_init(enum rx_intf_mode mode, u32 num_dma_symbol_to_pl, u32 num_dma_symbol_to_ps){

--- a/driver/sdr.c
+++ b/driver/sdr.c
@@ -693,7 +693,7 @@ static irqreturn_t openwifi_tx_interrupt(int irq, void *dev_id)
 				seq_no = ring->bds[ring->bd_rd_idx].seq_no;
 
 				if (seq_no == 0xffff) {// it has been forced cleared by the openwifi_tx (due to out-of-order Tx of different queues to the air?)
-					printk("%s openwifi_tx_interrupt: WARNING wr%d rd%d last_bd_rd_idx%d i%d pkt_cnt%d prio%d fpga q%d hwq len%d bd prio%d len_mpdu%d seq_no%d skb_linked%p dma_mapping_addr0x%u\n", sdr_compatible_str,
+					printk("%s openwifi_tx_interrupt: WARNING wr%d rd%d last_bd_rd_idx%d i%d pkt_cnt%d prio%d fpga q%d hwq len%d bd prio%d len_mpdu%d seq_no%d skb_linked%p dma_mapping_addr%u\n", sdr_compatible_str,
 					ring->bd_wr_idx, ring->bd_rd_idx, last_bd_rd_idx, i, pkt_cnt, prio, queue_idx, hw_queue_len, ring->bds[ring->bd_rd_idx].prio, ring->bds[ring->bd_rd_idx].len_mpdu, seq_no, ring->bds[ring->bd_rd_idx].skb_linked, ring->bds[ring->bd_rd_idx].dma_mapping_addr);
 					continue;
 				}

--- a/driver/sdr.c
+++ b/driver/sdr.c
@@ -693,7 +693,7 @@ static irqreturn_t openwifi_tx_interrupt(int irq, void *dev_id)
 				seq_no = ring->bds[ring->bd_rd_idx].seq_no;
 
 				if (seq_no == 0xffff) {// it has been forced cleared by the openwifi_tx (due to out-of-order Tx of different queues to the air?)
-					printk("%s openwifi_tx_interrupt: WARNING wr%d rd%d last_bd_rd_idx%d i%d pkt_cnt%d prio%d fpga q%d hwq len%d bd prio%d len_mpdu%d seq_no%d skb_linked%p dma_mapping_addr%llu\n", sdr_compatible_str,
+					printk("%s openwifi_tx_interrupt: WARNING wr%d rd%d last_bd_rd_idx%d i%d pkt_cnt%d prio%d fpga q%d hwq len%d bd prio%d len_mpdu%d seq_no%d skb_linked%p dma_mapping_addr0x%u\n", sdr_compatible_str,
 					ring->bd_wr_idx, ring->bd_rd_idx, last_bd_rd_idx, i, pkt_cnt, prio, queue_idx, hw_queue_len, ring->bds[ring->bd_rd_idx].prio, ring->bds[ring->bd_rd_idx].len_mpdu, seq_no, ring->bds[ring->bd_rd_idx].skb_linked, ring->bds[ring->bd_rd_idx].dma_mapping_addr);
 					continue;
 				}
@@ -1012,7 +1012,7 @@ static void openwifi_tx(struct ieee80211_hw *dev,
 			}
 			for (i=0; i<empty_bd_idx; i++) {
 				j = ( (ring->bd_wr_idx+i)&(NUM_TX_BD-1) );
-				printk("%s openwifi_tx: WARNING fake stop queue empty_bd_idx%d i%d lnx prio%d map to q%d stop%d hwq len%d wr%d rd%d bd prio%d len_mpdu%d seq_no%d skb_linked%p dma_mapping_addr%llu\n", sdr_compatible_str,
+				printk("%s openwifi_tx: WARNING fake stop queue empty_bd_idx%d i%d lnx prio%d map to q%d stop%d hwq len%d wr%d rd%d bd prio%d len_mpdu%d seq_no%d skb_linked%p dma_mapping_addr%u\n", sdr_compatible_str,
 				empty_bd_idx, i, prio, drv_ring_idx, ring->stop_flag, hw_queue_len, ring->bd_wr_idx, ring->bd_rd_idx, ring->bds[j].prio, ring->bds[j].len_mpdu, ring->bds[j].seq_no, ring->bds[j].skb_linked, ring->bds[j].dma_mapping_addr);
 				// tell Linux this skb failed
 				skb_new = ring->bds[j].skb_linked;
@@ -1038,7 +1038,7 @@ static void openwifi_tx(struct ieee80211_hw *dev,
 			}
 		} else {
 			j = ring->bd_wr_idx;
-			printk("%s openwifi_tx: WARNING real stop queue lnx prio%d map to q%d stop%d hwq len%d wr%d rd%d bd prio%d len_mpdu%d seq_no%d skb_linked%p dma_mapping_addr%llu\n", sdr_compatible_str,
+			printk("%s openwifi_tx: WARNING real stop queue lnx prio%d map to q%d stop%d hwq len%d wr%d rd%d bd prio%d len_mpdu%d seq_no%d skb_linked%p dma_mapping_addr%u\n", sdr_compatible_str,
 			prio, drv_ring_idx, ring->stop_flag, hw_queue_len, ring->bd_wr_idx, ring->bd_rd_idx, ring->bds[j].prio, ring->bds[j].len_mpdu, ring->bds[j].seq_no, ring->bds[j].skb_linked, ring->bds[j].dma_mapping_addr);
 	
 			ieee80211_stop_queue(dev, prio); // here we should stop those prio related to the queue idx flag set in TX_INTF_REG_S_AXIS_FIFO_NO_ROOM_read

--- a/driver/sdrctl_intf.c
+++ b/driver/sdrctl_intf.c
@@ -27,7 +27,7 @@ static int openwifi_testmode_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *
 		xpu_api->XPU_REG_CSMA_CFG_write(tmp); // unit us
 		return 0;
 	case OPENWIFI_CMD_GET_GAP:
-		skb = cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
+		skb = (struct sk_buff *)cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
 		if (!skb)
 			return -ENOMEM;
 		tmp = xpu_api->XPU_REG_CSMA_CFG_read();
@@ -48,7 +48,7 @@ static int openwifi_testmode_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *
 		}
 		return 0;
 	case OPENWIFI_CMD_GET_SLICE_IDX:
-		skb = cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
+		skb = (struct sk_buff *)cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
 		if (!skb)
 			return -ENOMEM;
 		tmp = priv->slice_idx;
@@ -69,7 +69,7 @@ static int openwifi_testmode_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *
 		}
 		return 0;
 	case OPENWIFI_CMD_GET_ADDR:
-		skb = cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
+		skb = (struct sk_buff *)cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
 		if (!skb)
 			return -ENOMEM;
 		if (priv->slice_idx>=MAX_NUM_HW_QUEUE) {
@@ -95,7 +95,7 @@ static int openwifi_testmode_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *
 		}
 		return 0;
 	case OPENWIFI_CMD_GET_SLICE_TOTAL:
-		skb = cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
+		skb = (struct sk_buff *)cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
 		if (!skb)
 			return -ENOMEM;
 		tmp = (xpu_api->XPU_REG_SLICE_COUNT_TOTAL_read());
@@ -117,7 +117,7 @@ static int openwifi_testmode_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *
 		}
 		return 0;
 	case OPENWIFI_CMD_GET_SLICE_START:
-		skb = cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
+		skb = (struct sk_buff *)cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
 		if (!skb)
 			return -ENOMEM;
 		tmp = (xpu_api->XPU_REG_SLICE_COUNT_START_read());
@@ -139,7 +139,7 @@ static int openwifi_testmode_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *
 		}
 		return 0;
 	case OPENWIFI_CMD_GET_SLICE_END:
-		skb = cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
+		skb = (struct sk_buff *)cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
 		if (!skb)
 			return -ENOMEM;
 		tmp = (xpu_api->XPU_REG_SLICE_COUNT_END_read());
@@ -206,7 +206,7 @@ static int openwifi_testmode_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *
 		printk("%s WARNING Please use command: sdrctl dev sdr0 set reg drv_xpu 0 reg_value! (1~2047, 0 means AUTO)!\n", sdr_compatible_str);
 		return -EOPNOTSUPP;
 	case OPENWIFI_CMD_GET_RSSI_TH:
-		skb = cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
+		skb = (struct sk_buff *)cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
 		if (!skb)
 			return -ENOMEM;
 		tmp_int = rssi_half_db_to_rssi_dbm(xpu_api->XPU_REG_LBT_TH_read(), priv->rssi_correction); //rssi_dbm
@@ -358,7 +358,7 @@ static int openwifi_testmode_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *
 		
 		return 0;
 	case REG_CMD_GET:
-		skb = cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
+		skb = (struct sk_buff *)cfg80211_testmode_alloc_reply_skb(hw->wiphy, nla_total_size(sizeof(u32)));
 		if (!skb)
 			return -ENOMEM;
 		reg_addr = nla_get_u32(tb[REG_ATTR_ADDR]);

--- a/driver/tx_intf/tx_intf.c
+++ b/driver/tx_intf/tx_intf.c
@@ -225,7 +225,7 @@ static const struct of_device_id dev_of_ids[] = {
 MODULE_DEVICE_TABLE(of, dev_of_ids);
 
 static struct tx_intf_driver_api tx_intf_driver_api_inst;
-static struct tx_intf_driver_api *tx_intf_api = &tx_intf_driver_api_inst;
+struct tx_intf_driver_api *tx_intf_api = &tx_intf_driver_api_inst;
 EXPORT_SYMBOL(tx_intf_api);
 
 static inline u32 hw_init(enum tx_intf_mode mode, u32 tx_config, u32 num_dma_symbol_to_ps, enum openwifi_fpga_type fpga_type){
@@ -437,7 +437,7 @@ static int dev_probe(struct platform_device *pdev)
 	if (IS_ERR(base_addr))
 		return PTR_ERR(base_addr);
 
-	printk("%s dev_probe io start 0x%08llx end 0x%08llx name %s flags 0x%08x desc 0x%08x\n", tx_intf_compatible_str,io->start,io->end,io->name,(u32)io->flags,(u32)io->desc);
+	printk("%s dev_probe io start 0x%08x end 0x%08x name %s flags 0x%08x desc 0x%08x\n", tx_intf_compatible_str,io->start,io->end,io->name,(u32)io->flags,(u32)io->desc);
 	printk("%s dev_probe base_addr 0x%p\n", tx_intf_compatible_str,(void*)base_addr);
 	printk("%s dev_probe tx_intf_driver_api_inst 0x%p\n", tx_intf_compatible_str, (void*)(&tx_intf_driver_api_inst) );
 	printk("%s dev_probe             tx_intf_api 0x%p\n", tx_intf_compatible_str, (void*)tx_intf_api);

--- a/driver/xpu/xpu.c
+++ b/driver/xpu/xpu.c
@@ -271,7 +271,7 @@ static const struct of_device_id dev_of_ids[] = {
 MODULE_DEVICE_TABLE(of, dev_of_ids);
 
 static struct xpu_driver_api xpu_driver_api_inst;
-static struct xpu_driver_api *xpu_api = &xpu_driver_api_inst;
+struct xpu_driver_api *xpu_api = &xpu_driver_api_inst;
 EXPORT_SYMBOL(xpu_api);
 
 static inline u32 hw_init(enum xpu_mode mode){


### PR DESCRIPTION
Hi Xianjun Jiao,

Compiling the driver for OpenWRT gave some errors. These are fixed in this commit and should not influence the default OpenWiFi behaviour.

The changes are mainly type casting and removing the static keyword from the module pointers. Some printf strings where wrongly formatted according to the compiler.

Kind regards,

Robbe Gaeremynck